### PR TITLE
+ [2.4-pre13] Added PacketEntityVelocity and InstantVector.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,6 +52,6 @@ dependencies {
     compileOnly("ink.ptms.core:v11200:11200:all")
     compileOnly("ink.ptms.core:v10900:10900:all")
     compileOnly("me.clip:placeholderapi:2.10.9")
-    compileOnly("me.arasple:TrMenu:3.0-PRE-18:pure")
+    compileOnly("me.arasple:TrMenu:3.0-PRE-20:pure")
     compileOnly(fileTree("libs"))
 }

--- a/src/main/kotlin/me/arasple/mc/trhologram/api/InstantVector.kt
+++ b/src/main/kotlin/me/arasple/mc/trhologram/api/InstantVector.kt
@@ -43,7 +43,7 @@ class InstantVector(val x: Double, val y: Double, val z: Double, val arrival: Lo
     companion object {
 
         @JvmStatic
-        fun fromVelocity(v: Vector, arrival: Long= 0) =
+        fun fromVector(v: Vector, arrival: Long= 0) =
             InstantVector(v.x, v.y, v.z, arrival)
 
     }

--- a/src/main/kotlin/me/arasple/mc/trhologram/api/InstantVector.kt
+++ b/src/main/kotlin/me/arasple/mc/trhologram/api/InstantVector.kt
@@ -1,0 +1,51 @@
+package me.arasple.mc.trhologram.api
+
+import me.arasple.mc.trhologram.api.nms.NMS
+import me.arasple.mc.trhologram.api.nms.packet.PacketEntityVelocity
+import org.bukkit.World
+import org.bukkit.entity.Player
+import org.bukkit.util.Vector
+import taboolib.common.platform.function.submit
+
+// 模 / 时间 = 速度
+class InstantVector(val x: Double, val y: Double, val z: Double, val arrival: Long = 0): Cloneable {
+
+    val useing = mutableMapOf<Int, InstantVector>()
+
+    val hasArrival get() = arrival > 0
+
+    val planVector: InstantVector get() {
+        if (!hasArrival) {
+            return this
+        }
+        return InstantVector(x / arrival, y / arrival, z / arrival)
+    }
+
+    fun useToVanilla(player: Player, entityId: Int) {
+        if (!hasArrival) {
+            NMS.INSTANCE.sendEntityPacket(player, PacketEntityVelocity(entityId, x, y, z))
+            return
+        }
+        val vec = planVector
+        useing[entityId] = vec
+        NMS.INSTANCE.sendEntityPacket(player, PacketEntityVelocity(entityId, vec.x, vec.y, vec.z))
+        submit(delay = arrival) {
+            NMS.INSTANCE.sendEntityPacket(player, PacketEntityVelocity(entityId, 0.0, 0.0, 0.0))
+        }
+    }
+
+    fun toPosition(w: World) =
+        Position(w, x, y, z)
+
+    override fun clone() =
+        super.clone() as InstantVector
+
+    companion object {
+
+        @JvmStatic
+        fun fromVelocity(v: Vector, arrival: Long= 0) =
+            InstantVector(v.x, v.y, v.z, arrival)
+
+    }
+
+}

--- a/src/main/kotlin/me/arasple/mc/trhologram/api/InstantVector.kt
+++ b/src/main/kotlin/me/arasple/mc/trhologram/api/InstantVector.kt
@@ -31,6 +31,7 @@ class InstantVector(val x: Double, val y: Double, val z: Double, val arrival: Lo
         NMS.INSTANCE.sendEntityPacket(player, PacketEntityVelocity(entityId, vec.x, vec.y, vec.z))
         submit(delay = arrival) {
             NMS.INSTANCE.sendEntityPacket(player, PacketEntityVelocity(entityId, 0.0, 0.0, 0.0))
+            useing.remove(entityId)
         }
     }
 

--- a/src/main/kotlin/me/arasple/mc/trhologram/api/Position.kt
+++ b/src/main/kotlin/me/arasple/mc/trhologram/api/Position.kt
@@ -4,47 +4,58 @@ import org.bukkit.Bukkit
 import org.bukkit.Location
 import org.bukkit.World
 import kotlin.math.pow
+import kotlin.math.sqrt
 
 /**
  * @author Arasple
  * @date 2021/2/10 10:53
  */
-class Position(
-    val world: World = Bukkit.getWorlds()[0],
-    val x: Double = 0.0,
-    val y: Double = 0.0,
-    val z: Double = 0.0
-) {
+class Position: Cloneable {
 
-    fun distance(position: Position): Double {
-        return distance(position.x, position.y, position.z)
+    val world: World
+    val x: Double
+    val y: Double
+    val z: Double
+
+    constructor(x: Double = 0.0, y: Double = 0.0, z: Double = 0.0) : this(Bukkit.getWorlds()[0], x, y, z)
+
+    constructor(world: World = Bukkit.getWorlds()[0], x: Double = 0.0, y: Double = 0.0, z: Double = 0.0) {
+        this.world = world
+        this.x = x
+        this.y = y
+        this.z = z
     }
 
-    fun distance(location: Location): Double {
-        return distance(location.x, location.y, location.z)
-    }
+    fun distance(l: Position) =
+        distance(l.x, l.y, l.z)
 
-    fun clone(x: Double = 0.0, y: Double = 0.0, z: Double = 0.0): Position {
-        return Position(world, this.x + x, this.y + y, this.z + z)
-    }
+    fun distance(l: Location) =
+        distance(l.x, l.y, l.z)
 
-    private fun distance(x: Double, y: Double, z: Double): Double {
-        return Math.sqrt((this.x - x).pow(2) + (this.y - y).pow(2) + (this.z - z).pow(2))
-    }
+    fun clone(x: Double = 0.0, y: Double = 0.0, z: Double = 0.0) =
+        Position(world, this.x + x, this.y + y, this.z + z)
 
-    fun toLocation(): Location {
-        return Location(world, x, y, z)
-    }
+    private fun distance(x: Double, y: Double, z: Double) =
+        sqrt((this.x - x).pow(2) + (this.y - y).pow(2) + (this.z - z).pow(2))
 
-    override fun toString(): String {
-        return "${world.name} ~ $x, $y, $z"
+    fun toVelocity() =
+        InstantVector(x, y, z)
+
+    fun toLocation() =
+        Location(world, x, y, z)
+
+    override fun toString() =
+        "${world.name} ~ $x, $y, $z"
+
+    override fun clone(): Location {
+        return super.clone() as Location
     }
 
     companion object {
 
-        fun fromLocation(location: Location): Position {
-            return Position(location.world!!, location.x, location.y, location.z)
-        }
+        @JvmStatic
+        fun fromLocation(l: Location) =
+            Position(l.world!!, l.x, l.y, l.z)
 
     }
 

--- a/src/main/kotlin/me/arasple/mc/trhologram/api/nms/NMSImpl.kt
+++ b/src/main/kotlin/me/arasple/mc/trhologram/api/nms/NMSImpl.kt
@@ -44,6 +44,10 @@ class NMSImpl : NMS() {
             val id = it.entityId
 
             when (it) {
+                // Set Entity velocity
+                is PacketEntityVelocity -> {
+                    sendPacket(player, PacketPlayOutEntityVelocity(id, Vec3D(it.x, it.y, it.z)))
+                }
                 // Destroy entity
                 is PacketEntityDestroy -> sendPacket(player, PacketPlayOutEntityDestroy(id))
                 // Spawn Armor Stand

--- a/src/main/kotlin/me/arasple/mc/trhologram/api/nms/packet/PacketEntityVelocity.kt
+++ b/src/main/kotlin/me/arasple/mc/trhologram/api/nms/packet/PacketEntityVelocity.kt
@@ -1,0 +1,5 @@
+package me.arasple.mc.trhologram.api.nms.packet
+
+import me.arasple.mc.trhologram.api.InstantVector
+
+class PacketEntityVelocity(entityId: Int, val x: Double, val y: Double, val z: Double): PacketEntity(entityId)


### PR DESCRIPTION
添加向量的实施、应用

可通过InstantVector实现丝滑地移向目标位置:
```
InstantVector.fromVector(bukkitVector)
InstantVector#useToVanilla(player, entityId)
```